### PR TITLE
Add CommonJS, AMD and npm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "image-sequencer",
+  "version": "2.0.1",
+  "description": "Sequencer - A fast(?) fullscreen image-sequence player",
+  "main": "sequencer/sequencer.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ertdfgcvb/Sequencer.git"
+  },
+  "keywords": [
+    "image",
+    "sequence",
+    "sequencer"
+  ],
+  "author": "Andreas Gysin",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/ertdfgcvb/Sequencer/issues"
+  },
+  "homepage": "https://github.com/ertdfgcvb/Sequencer#readme"
+}

--- a/sequencer/sequencer.js
+++ b/sequencer/sequencer.js
@@ -11,8 +11,22 @@
 //      http://ertdfgcvb.com/sequencer
 //      http://github.com/ertdfgcvb/Sequencer
 
-var Sequencer = (function (global, document) {
-
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], function() {
+          return factory(window, document);
+        });
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory(window, document);
+    } else {
+        // Browser globals (root is window)
+        root.Sequencer = factory(root, document);
+  }
+}(this, function (window, document) {
     'use strict';
 
     var instances = [];
@@ -167,7 +181,7 @@ var Sequencer = (function (global, document) {
         },
 
         size : function(w, h){
-            var r = this.config.retina ? global.devicePixelRatio : 1;
+            var r = this.config.retina ? window.devicePixelRatio : 1;
             var c = this.ctx.canvas;
             c.width = w * r;
             c.height = h * r;
@@ -268,7 +282,7 @@ var Sequencer = (function (global, document) {
 
         var t = self.images.length;
         var m, w;
-        var r = self.config.retina ? global.devicePixelRatio : 1;
+        var r = self.config.retina ? window.devicePixelRatio : 1;
 
         var ox = e.offsetX || e.touches[0].pageX - e.touches[0].target.offsetLeft;
         var oy = e.offsetY || e.touches[0].pageY - e.touches[0].target.offsetTop;
@@ -396,7 +410,4 @@ var Sequencer = (function (global, document) {
         make      : make,
         instances : instances
     };
-})(window, document);
-
-
-
+}));


### PR DESCRIPTION
Firstly, thanks for writing such a useful library! I'm making use of it in a project at the moment and have made a couple of small enhancements to make it easier to use with module bundlers like Browserify and webpack and dependency managers like npm and Yarn.

This pull request adds support for CommonJS and AMD environments by replacing the IIFE closure with a UMD wrapper and also adds a package.json file to enable this library to be used as a npm package. I chose the package name 'image-sequencer' because 'sequencer' and 'sequencer.js' were already taken, but I haven't published it to npm, so this can change if you'd like it to.

I've verified that the examples in this repo all work correctly under CommonJS, AMD and with browser globals still.

I hope you find these changes useful!